### PR TITLE
Fix unique constraint violation when updating remap table

### DIFF
--- a/workpackages/test/config-farm-duplicate-wp.yml
+++ b/workpackages/test/config-farm-duplicate-wp.yml
@@ -1,0 +1,25 @@
+file: farms.gpkg
+
+work-packages:
+  - name: Kyle
+    value: 4
+    mergin-project: martin/farms-Kyle
+
+  - name: Kyle_duplicate
+    value: 4
+    mergin-project: martin/farms-Kyle-duplicate
+
+  - name: Emma
+    value:
+      - 1
+      - 2
+    mergin-project: martin/farms-Emma
+
+tables:
+  - name: farms
+    method: filter-column
+    filter-column-name: fid
+  - name: trees
+    method: filter-column
+    filter-column-name: farm_id
+    


### PR DESCRIPTION
Fixes #38

This could happen because we were keeping outdated entries in remap tables of work packages - the tuples (master_fid, wp_fid) would get added as needed, but they were never getting deleting when the corresponding features got deleted. As a result, users could get an error from SQLite about unique constraint violation when inserting to the remap table because the master_fid already existed there from some previous runs.